### PR TITLE
Add Remote Plugin Installer plugin

### DIFF
--- a/remote-plugin-installer/admin/plugin-list.php
+++ b/remote-plugin-installer/admin/plugin-list.php
@@ -1,0 +1,55 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Render list of available plugins for installation.
+ *
+ * @param string $token API token.
+ */
+function rpi_render_plugin_list( $token ) {
+    $api = new RPI_API_Client();
+
+    $validation = $api->validate_token( $token );
+    if ( ! $validation ) {
+        echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid token.', 'remote-plugin-installer' ) . '</p></div>';
+        return;
+    }
+
+    if ( isset( $_POST['rpi_install'] ) && ! empty( $_POST['download_url'] ) ) {
+        check_admin_referer( 'rpi_install_plugin' );
+        $download_url = esc_url_raw( $_POST['download_url'] );
+        $result       = rpi_install_remote_plugin( $download_url );
+
+        if ( is_wp_error( $result ) ) {
+            echo '<div class="notice notice-error"><p>' . esc_html( $result->get_error_message() ) . '</p></div>';
+        } else {
+            echo '<div class="notice notice-success"><p>' . esc_html__( 'Plugin installed successfully.', 'remote-plugin-installer' ) . '</p></div>';
+        }
+    }
+
+    $plugins = $api->get_plugins( $token );
+    if ( ! $plugins ) {
+        echo '<div class="notice notice-error"><p>' . esc_html__( 'Unable to load plugins.', 'remote-plugin-installer' ) . '</p></div>';
+        return;
+    }
+
+    echo '<div class="rpi-plugin-list">';
+    foreach ( $plugins as $plugin ) {
+        $name         = isset( $plugin['name'] ) ? $plugin['name'] : '';
+        $desc         = isset( $plugin['description'] ) ? $plugin['description'] : '';
+        $download_url = isset( $plugin['download_url'] ) ? $plugin['download_url'] : '';
+
+        echo '<div class="rpi-card">';
+        echo '<h2>' . esc_html( $name ) . '</h2>';
+        echo '<p>' . esc_html( $desc ) . '</p>';
+        echo '<form method="post">';
+        wp_nonce_field( 'rpi_install_plugin' );
+        echo '<input type="hidden" name="download_url" value="' . esc_url( $download_url ) . '" />';
+        echo '<button type="submit" name="rpi_install" class="button button-primary">' . esc_html__( 'Install', 'remote-plugin-installer' ) . '</button>';
+        echo '</form>';
+        echo '</div>';
+    }
+    echo '</div>';
+}

--- a/remote-plugin-installer/admin/settings-page.php
+++ b/remote-plugin-installer/admin/settings-page.php
@@ -1,0 +1,52 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Render plugin settings page.
+ */
+function rpi_render_settings_page() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    $message = '';
+
+    if ( isset( $_POST['rpi_token'] ) ) {
+        check_admin_referer( 'rpi_save_token' );
+        $token = sanitize_text_field( wp_unslash( $_POST['rpi_token'] ) );
+        update_option( 'rpi_api_token', $token );
+        delete_transient( 'rpi_plugins_' . md5( $token ) );
+        $message = __( 'Token saved.', 'remote-plugin-installer' );
+    }
+
+    $token = get_option( 'rpi_api_token', '' );
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Remote Plugin Installer', 'remote-plugin-installer' ); ?></h1>
+        <?php if ( $message ) : ?>
+            <div class="notice notice-success"><p><?php echo esc_html( $message ); ?></p></div>
+        <?php endif; ?>
+        <form method="post">
+            <?php wp_nonce_field( 'rpi_save_token' ); ?>
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row">
+                        <label for="rpi_token"><?php esc_html_e( 'API Token', 'remote-plugin-installer' ); ?></label>
+                    </th>
+                    <td>
+                        <input name="rpi_token" type="text" id="rpi_token" value="<?php echo esc_attr( $token ); ?>" class="regular-text" />
+                        <p class="description"><?php esc_html_e( 'Enter the API token provided by the remote site.', 'remote-plugin-installer' ); ?></p>
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button( __( 'Save Token', 'remote-plugin-installer' ) ); ?>
+        </form>
+    </div>
+    <?php
+
+    if ( $token ) {
+        rpi_render_plugin_list( $token );
+    }
+}

--- a/remote-plugin-installer/assets/css/style.css
+++ b/remote-plugin-installer/assets/css/style.css
@@ -1,0 +1,16 @@
+.rpi-plugin-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.rpi-card {
+    background: #fff;
+    border: 1px solid #ccd0d4;
+    padding: 15px;
+    width: 280px;
+}
+
+.rpi-card h2 {
+    margin-top: 0;
+}

--- a/remote-plugin-installer/includes/api-client.php
+++ b/remote-plugin-installer/includes/api-client.php
@@ -1,0 +1,73 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Simple API client for communicating with remote site.
+ */
+class RPI_API_Client {
+
+    /**
+     * Base URL of remote API.
+     *
+     * @var string
+     */
+    private $base_url = 'https://midominio.com/api/';
+
+    /**
+     * Validate a token against the API.
+     *
+     * @param string $token API token.
+     * @return array|false
+     */
+    public function validate_token( $token ) {
+        $response = wp_remote_post(
+            $this->base_url . 'validate-token',
+            array(
+                'headers' => array( 'Content-Type' => 'application/json' ),
+                'body'    => wp_json_encode( array( 'token' => $token ) ),
+                'timeout' => 15,
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return false;
+        }
+
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( isset( $data['valid'] ) && $data['valid'] ) {
+            return $data;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get available plugins from API.
+     *
+     * @param string $token API token.
+     * @return array|false
+     */
+    public function get_plugins( $token ) {
+        $transient_key = 'rpi_plugins_' . md5( $token );
+        $plugins       = get_transient( $transient_key );
+
+        if ( false === $plugins ) {
+            $url      = $this->base_url . 'my-plugins?token=' . urlencode( $token );
+            $response = wp_remote_get( $url, array( 'timeout' => 15 ) );
+
+            if ( is_wp_error( $response ) ) {
+                return false;
+            }
+
+            $plugins = json_decode( wp_remote_retrieve_body( $response ), true );
+
+            if ( is_array( $plugins ) ) {
+                set_transient( $transient_key, $plugins, HOUR_IN_SECONDS );
+            }
+        }
+
+        return $plugins;
+    }
+}

--- a/remote-plugin-installer/includes/installer.php
+++ b/remote-plugin-installer/includes/installer.php
@@ -1,0 +1,29 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Download and install plugin from a remote zip URL.
+ *
+ * @param string $download_url URL to the plugin zip file.
+ * @return true|WP_Error
+ */
+function rpi_install_remote_plugin( $download_url ) {
+    include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+    include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+    include_once ABSPATH . 'wp-admin/includes/file.php';
+
+    $upgrader = new Plugin_Upgrader();
+    $result   = $upgrader->install( $download_url );
+
+    if ( is_wp_error( $result ) ) {
+        return $result;
+    }
+
+    if ( $result ) {
+        return true;
+    }
+
+    return new WP_Error( 'install_failed', __( 'Installation failed.', 'remote-plugin-installer' ) );
+}

--- a/remote-plugin-installer/remote-plugin-installer.php
+++ b/remote-plugin-installer/remote-plugin-installer.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Plugin Name: Remote Plugin Installer
+ * Description: Download and install plugins from a remote site.
+ * Version: 1.0.0
+ * Author: Example Author
+ * Text Domain: remote-plugin-installer
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! defined( 'RPI_DIR' ) ) {
+    define( 'RPI_DIR', plugin_dir_path( __FILE__ ) );
+}
+if ( ! defined( 'RPI_URL' ) ) {
+    define( 'RPI_URL', plugin_dir_url( __FILE__ ) );
+}
+
+/**
+ * Load plugin text domain for translations.
+ */
+function rpi_load_textdomain() {
+    load_plugin_textdomain( 'remote-plugin-installer', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'plugins_loaded', 'rpi_load_textdomain' );
+
+require_once RPI_DIR . 'includes/api-client.php';
+require_once RPI_DIR . 'includes/installer.php';
+require_once RPI_DIR . 'admin/settings-page.php';
+require_once RPI_DIR . 'admin/plugin-list.php';
+
+/**
+ * Register settings page under Settings menu.
+ */
+function rpi_add_admin_menu() {
+    add_options_page(
+        __( 'Plugin Remoto', 'remote-plugin-installer' ),
+        __( 'Plugin Remoto', 'remote-plugin-installer' ),
+        'manage_options',
+        'remote-plugin-installer',
+        'rpi_render_settings_page'
+    );
+}
+add_action( 'admin_menu', 'rpi_add_admin_menu' );
+
+/**
+ * Enqueue admin styles on plugin page.
+ */
+function rpi_enqueue_assets( $hook ) {
+    if ( 'settings_page_remote-plugin-installer' !== $hook ) {
+        return;
+    }
+
+    wp_enqueue_style( 'rpi-admin', RPI_URL . 'assets/css/style.css', array(), '1.0.0' );
+}
+add_action( 'admin_enqueue_scripts', 'rpi_enqueue_assets' );


### PR DESCRIPTION
## Summary
- add WordPress plugin `Remote Plugin Installer`
- handle settings page and token storage
- list remote plugins and install them
- include API client and installer utilities
- add minimal admin CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849a0a4d6788324846a555bf5642c21